### PR TITLE
chore: Migrate from release-please v3 to v2

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,12 +1,23 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
 jobs:
-  release-job:
+  release-please:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Release with release-please
-        uses: google-github-actions/release-please-action@v2
+      - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options


### PR DESCRIPTION
Migrated from release-please v3 to v2 and removed unnecessary workflows:
- Removed the `check-pr-title` workflow.
- Removed the `pr-tests-coverage` workflow.
- Simplified the `release-please` workflow to use only one job.
- Removed the artifact upload step from the release job.